### PR TITLE
Adjust thumbnail focus highlights

### DIFF
--- a/header-panel.less
+++ b/header-panel.less
@@ -38,7 +38,7 @@
                 &:hover{
                     background-color: transparent;
                 }
-            } 
+            }
         }
 
         .options{

--- a/left-panel.less
+++ b/left-panel.less
@@ -1,0 +1,19 @@
+.uv.en-gb {
+  .leftPanel {
+    .views {
+      .thumbsView {
+        &:focus {
+          outline: none;
+        }
+
+        .thumbs {
+          .thumb.selected {
+            .wrap {
+              border-color: @panel-border-color;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/theme.less
+++ b/theme.less
@@ -1,3 +1,4 @@
 @import 'variables';
 @import 'header-panel';
 @import 'footer-panel';
+@import 'left-panel';


### PR DESCRIPTION
Closes #2 (part of sul-dlss/content_search#33)

- [x] Eliminate the blue-bordered highlight that surrounds the thumbnail area when a document is selected (to be replaced with a more prominent document highlight).
- [x] Eliminate the white-bordered styling on the currently selected thumbnail (covered by the more prominent document highlight mentioned above).

## Before
![focus-enabled](https://user-images.githubusercontent.com/5402927/35599405-78f6f3e8-05dd-11e8-9def-f74abac7ad91.gif)

## After
![disabled-focus](https://user-images.githubusercontent.com/5402927/35599407-7ae271aa-05dd-11e8-8bac-1963c67fbd76.gif)
