### PR TITLE
Restore and restyle focus highlight

### DIFF
--- a/left-panel.less
+++ b/left-panel.less
@@ -1,6 +1,26 @@
 .uv.en-gb {
   .leftPanel {
     .views {
+      .galleryView {
+        .thumbs {
+          .thumb {
+            border: 2px solid @left-panel-bkgd;
+
+            .wrap {
+              border: none;
+            }
+          }
+
+          .thumb.selected {
+            border: 2px solid @yellow;
+
+            .wrap {
+              border: none;
+            }
+          }
+        }
+      }
+
       .thumbsView {
         &:focus {
           outline: none;
@@ -9,6 +29,7 @@
         .thumbs {
           .thumb {
             padding-top: 2px;
+
             .wrap {
               border: none;
 

--- a/left-panel.less
+++ b/left-panel.less
@@ -7,9 +7,27 @@
         }
 
         .thumbs {
-          .thumb.selected {
+          .thumb {
+            padding-top: 2px;
             .wrap {
-              border-color: @panel-border-color;
+              border: none;
+
+              img {
+                margin: 0 auto;
+              }
+            }
+          }
+
+          .thumb.twoCol {
+            margin-right: 3px;
+            border: 2px solid @left-panel-bkgd;
+          }
+
+          .thumb.selected {
+            border: 2px solid @yellow;
+
+            .wrap {
+              border: none;
             }
           }
         }

--- a/variables.less
+++ b/variables.less
@@ -3,6 +3,8 @@
 @brand-secondary:               #0098db;
 @link-color:                    #0098db;
 @dark-red:                      #820000;
+@yellow:                        #ffc40d;
+@left-panel-bkgd:                #212121;
 
 // Responsive sizes
 


### PR DESCRIPTION
Fixes #4 

This PR adds a more prominent yellow highlight to selected thumbnails. 

To test this locally:
- clone both [sul-dlss/universalviewer](github.com/sul-dlss/universalviewer) and [sul-dlss/sul-embed](https://github.com/sul-dlss/sul-embed/)
- edit universalviewer's package.json so that it points at this branch: `"uv-en-gb-theme": "sul-dlss/uv-en-gb-theme#restore-focus-highlight"`
- follow [build instructions on the wiki](https://github.com/sul-dlss/sul-embed/wiki/Updating-sul-embeds-Universal-Viewer) 

## After
### Single page view
<img width="266" alt="single page" src="https://user-images.githubusercontent.com/5402927/36049126-89b64a1a-0d96-11e8-94e5-b75dc9a4e713.png">

### Two page view
<img width="263" alt="two page" src="https://user-images.githubusercontent.com/5402927/36049128-89cc6ea8-0d96-11e8-975c-4175f6ecd5a0.png">

### Gallery view
<img width="410" alt="gallery view" src="https://user-images.githubusercontent.com/5402927/36054876-97da30ea-0dad-11e8-8c9b-ccfb40eccb6b.png">
