### PR TITLE
Hide hit counters in thumbnail panel

### DIFF
--- a/left-panel.less
+++ b/left-panel.less
@@ -30,6 +30,12 @@
           .thumb {
             padding-top: 2px;
 
+            .info {
+              .searchResults {
+                display: none;
+              }
+            }
+
             .wrap {
               border: none;
 


### PR DESCRIPTION
Closes #7 

This PR hides the content search hit counters in the thumbnail panel until we have a more accurate way of counting hits-per-page.

**Example PURL:** [cc842mn9348](https://sul-purl-uat.stanford.edu/cc842mn9348)
## Testing locally:
- Clone down sul-embed, sul-dlss/universalviewer, and this theme repo
- In config/settings.yml change `purl_url` and `valid_purl_url` to point at sul-purl-uat
- In your local `universalviewer/package.json`, update the `uv-en-GB-theme` to point at this branch (`sul-dlss/uv-en-gb-theme#7-hide-thumnail-hit-counts`)
- in your local `sul-embed` directory, run the following script: 
```
echo ...🌑 starting UniversalViewer theme teardown and build 🌕... && cd ../universalviewer/ && echo ✂️ ...Removing node_modules and themes... ✂️ && rm -rf src/themes && rm -rf node_modules/ && echo ...downloading 📦... && npm install && echo ...🛠 building... && grunt build; cd - && bundle exec rake uv:update && echo 3...2...1...🚀 && be rails s
```
- open `http://localhost:3000/iframe?url=https://sul-purl-uat.stanford.edu/cc842mn9348&#?c=0&m=0&s=0&cv=2&xywh=-5101%2C0%2C15227%2C3533`

## Before

<img width="964" alt="hit counters showing" src="https://user-images.githubusercontent.com/5402927/39078324-cb80615c-44bd-11e8-8127-bbf7fcd1b82e.png">

## After
<img width="926" alt="hit counters hidden" src="https://user-images.githubusercontent.com/5402927/39078325-cdfa69e6-44bd-11e8-923a-b5f71cab078a.png">

**Note:** @ggeisler I'm not able to hide the counters in gallery view mode. There's an inline style that's overriding my `display:none`. It wouldn't accessible at all, but I could try and change the font color to match the background color. Let me know if hopping on a call to discuss would be useful.

<img width="913" alt="gallery view; hit counters showing" src="https://user-images.githubusercontent.com/5402927/39139162-0a35e416-46d6-11e8-9295-d50ebd70a4cf.png">

